### PR TITLE
port configuration of -1 can allocate illegal ports

### DIFF
--- a/src/main/kotlin/me/ruslanys/web/HttpServer.kt
+++ b/src/main/kotlin/me/ruslanys/web/HttpServer.kt
@@ -26,7 +26,7 @@ class HttpServer(@Value("\${server.port:8080}") port: Int,
 
     init {
         if (port == -1) {
-            this.port = Random().nextInt(65_535)
+            this.port = 1024 + Random().nextInt(48_128)
         } else {
             this.port = port
         }


### PR DESCRIPTION
Set the lower port limit and exclude IANA ports range (49152-65535).

So, the User Ports are 1024-49151.